### PR TITLE
Adding if __name__ == __main__ and fixing pep8 warnings

### DIFF
--- a/inverter.py
+++ b/inverter.py
@@ -13,16 +13,19 @@ import sys
 
 MIRROR_FILE = 'mirror.json'
 
+
 def load_mirror():
     """Returns a dict, mapping instuctions to opposite instructions."""
     with open(MIRROR_FILE) as mirror_file:
         return json.load(mirror_file)
+
 
 def invert(instruction, mirror):
     """Returns the opposite (if exists) of an instruction."""
     if instruction in mirror:
         return mirror[instruction]
     return instruction
+
 
 def main():
     """Entry point."""
@@ -42,4 +45,6 @@ def main():
         instruction[0] = invert(instruction[0], mirror)
         print(' '.join(instruction))
 
-main()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Pep8 says that there should be two blank lines between classes and functions.
__name__ is set to "__main__" if the script is executed directly and not imported.